### PR TITLE
fix: depend on preact version range instead of exact version

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -5770,9 +5770,9 @@
   },
   "imports": {
     "@preact-icons/common": "jsr:@preact-icons/common@^1.0.12",
-    "preact": "npm:preact@10.22.1",
-    "preact/jsx-runtime": "npm:preact@10.22.1/jsx-runtime",
-    "preact/hooks": "npm:preact@10.22.1/hooks"
+    "preact": "npm:preact@^10.22.1",
+    "preact/jsx-runtime": "npm:preact@^10.22.1/jsx-runtime",
+    "preact/hooks": "npm:preact@^10.22.1/hooks"
   },
   "publish": {
     "exclude": [


### PR DESCRIPTION
There is no need to exactly depend on Preact `10.22.1`. By using a range instead we ensure that users don't end up with duplicate copies of Preact.